### PR TITLE
Revert "Fixed gtk entry width problem in Trisquel 8"

### DIFF
--- a/user_interface/feed.py
+++ b/user_interface/feed.py
@@ -566,13 +566,11 @@ class AbstractMenu:
                       self.ipv4_field3, self.ipv4_field4):
             field.set_max_length(3)
             field.set_width_chars(3)
-            field.set_max_width_chars(3)
             field.set_input_purpose(Gtk.InputPurpose.DIGITS)
 
         self.port_entry = Gtk.Entry()
         self.port_entry.set_max_length(5)
         self.port_entry.set_width_chars(5)
-        self.port_entry.set_max_width_chars(5)
         self.port_entry.set_input_purpose(Gtk.InputPurpose.DIGITS)
 
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)


### PR DESCRIPTION
Reverting since Trisquel 7 is using GTK 3.10 and set_max_width_chars() is available in 3.12.